### PR TITLE
Content-Type header Added in REST call to upload the index template

### DIFF
--- a/Documentation.md
+++ b/Documentation.md
@@ -263,7 +263,7 @@ upload it you nshould make a REST call to the following Elasticsearch
 endpoint. You may use curl to do it. If you save our template (3.2) as
 template.json, you could just run the following command:
 
-`curl -XPUT localhost:9200/_template/blueliv -d @template.json`
+`curl -XPUT -H 'Content-Type: application/json' localhost:9200/_template/blueliv -d @template.json`
 
 ```
 {


### PR DESCRIPTION
Starting from Elasticsearch 6.0, all REST requests that include a body must also provide the correct content-type for that body.